### PR TITLE
Add in Albon's ML FlashCards

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ Notebooks tested with Python 2.7.x.(will soon be updated to Python 3.5+)
 * Machine Learning Blogs https://machinelearningblogs.com/ [(RSS)](https://machinelearningblogs.com/feed/)
 * Machine Learning, etc http://yaroslavvb.blogspot.com [(RSS)](http://yaroslavvb.blogspot.com/feeds/posts/default)
 * Machine Learning, Maths and Physics https://mlopezm.wordpress.com/ [(RSS)](https://mlopezm.wordpress.com/feed/)
+* Machine Learning Flashcards https://machinelearningflashcards.com/ $10, but a nicely illustrated set of 300 flash cards
 * Machined Learnings http://www.machinedlearnings.com/ [(RSS)](http://www.machinedlearnings.com/feeds/posts/default)
 * MAPPING BABEL https://jack-clark.net/ [(RSS)](https://jack-clark.net/feed/)
 * MAPR Blog https://www.mapr.com/blog [(RSS)](https://www.mapr.com/bigdata.xml)


### PR DESCRIPTION
Link to Chris Albon's ML flash cards. Not really a blog as such, but still a nice reference for people that want quick refreshers.