### PR TITLE
docs: fix simple typo, sepcified -> specified

### DIFF
--- a/java/java2py/antlr-3.1.3/runtime/JavaScript/src/org/antlr/runtime/BitSet.js
+++ b/java/java2py/antlr-3.1.3/runtime/JavaScript/src/org/antlr/runtime/BitSet.js
@@ -423,7 +423,7 @@ org.antlr.runtime.BitSet.prototype = {
      * current values.  If one argument is passed sets each bit from the
      * beginning of the bit set to index1 (inclusive) to the complement of its
      * current value.  If two arguments are passed sets each bit from the
-     * specified index1 (inclusive) to the sepcified index2 (inclusive) to the
+     * specified index1 (inclusive) to the specified index2 (inclusive) to the
      * complement of its current value.
      * @param {Number} index1
      * @param {Number} index2


### PR DESCRIPTION
There is a small typo in java/java2py/antlr-3.1.3/runtime/JavaScript/src/org/antlr/runtime/BitSet.js.

Should read `specified` rather than `sepcified`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md